### PR TITLE
マイページの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,9 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
+    # 新規登録時にニックネーム,生年月日の取得を許可
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :birthdate])
+    # 情報更新時にニックネーム,生年月日の取得を許可
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :birthdate])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
-  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -18,12 +17,5 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
-  end
-
-  def configure_permitted_parameters
-    # 新規登録時にニックネーム,生年月日の取得を許可
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :birthdate])
-    # 情報更新時にニックネーム,生年月日の取得を許可
-    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :birthdate])
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  # 更新時にパスワードを不要とする
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
+  def configure_sign_up_params
+    # 新規登録時にニックネーム,生年月日の取得を許可
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :birthdate])
+  end
+
+  def configure_account_update_params
+    # 情報更新時にニックネーム,生年月日の取得を許可
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :birthdate])
+  end
+
+  # 更新後は習慣カウントページへ遷移
+  def after_update_path_for(_resource)
+    habits_path
+  end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  attr_accessor :current_password
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -9,15 +9,15 @@ class User < ApplicationRecord
   has_many :habits
   has_one  :rule
 
+  # 存在すること・確認用を含めて2回入力はデフォルト実装のため省略 安全性を高めるために10文字以上に設定
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+  validates :password, format: { with: PASSWORD_REGEX }, length: { minimum: 10 }, on: :create
+  validates :password, confirmation: true, on: :create
+
   with_options presence: true do
     validates :nickname, length: { maximum: 10 }
     validates :birthdate
     # @含むこと・存在することはdeviseのデフォルト実装のため省略
     validates :email, uniqueness: true
-    # 存在すること・確認用を含めて2回入力はデフォルト実装のため省略 安全性を高めるために10文字以上に設定
-    validates :password, length: { minimum: 10 }
-    # パスワードが半角英数字（空文字NG）以外の場合には、メッセージを出す
-    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-    validates_format_of :password, with: PASSWORD_REGEX, message: '半角英数字で入力してください'
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,55 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="wrapper">
+<%= render "shared/third-header" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_with model: @user, url: registration_path(resource_name), class: 'registration-main', autocomplete: 'off', local: true do |f| %>
+  <div class='form-wrap'>
+    <div class='form-header'>
+      <h1 class='form-header-text'>
+        ユーザー情報の編集
+      </h1>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <%= render 'shared/error_messages', model: f.object %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+    <div class="form-group">
+      <div class='form-text-wrap'>
+        <label class="form-text">ニックネーム</label>
+      </div>
+      <%= f.text_area :nickname, class:"input-default", id:"nickname", placeholder:"10文字以下", maxlength:"10" , autofocus: true %>
+    </div>
+    <div class="form-group">
+      <div class='form-text-wrap'>
+        <label class="form-text">メールアドレス</label>
+      </div>
+      <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autocomplete: 'off' %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
+    <div class="form-group">
+      <div class='form-text-wrap'>
+        <label class="form-text">生年月日</label>
+        <span class="indispensable">必須</span>
+      </div>
+      <div class='input-birth-wrap'>
+        <%= raw sprintf(
+                    f.date_select(
+                      :birthdate,
+                      class:'select-birth',
+                      id:"birth-date",
+                      use_month_numbers: true,
+                      prompt:'--',
+                      start_year: 1930,
+                      end_year: (Time.now.year - 5),
+                      date_separator: '%s'),
+                    "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
+      </div>
+    
+    <div class='login-btn'>
+      <%= f.submit "更新する", class:"login-red-btn" %>
+    </div>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/shared/_login_after_header.html.erb
+++ b/app/views/shared/_login_after_header.html.erb
@@ -2,7 +2,7 @@
 <header class='login_after_header'>
     <div class='left_menu_login_after'>
       <%= link_to image_tag("icon.png", class:"action-icon"), habits_path %>
-      <%= "#{current_user.nickname}さんのページ"%>
+      <%= link_to "#{current_user.nickname}さんのページ", edit_user_registration_path %>
     </div>
     <div class='right_menu_login_after'>
       <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   root to: 'homes#index'
   get 'homes/index'
   resources :objectives

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
       it 'パスワードが空欄だと保存できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include('パスワードを入力してください', 'パスワードは10文字以上で入力してください', 'パスワード半角英数字で入力してください',
+        expect(@user.errors.full_messages).to include('パスワードを入力してください', 'パスワードは10文字以上で入力してください', 'パスワードは不正な値です',
                                                       'パスワード（確認用）とパスワードの入力が一致しません')
       end
       it 'パスワード（確認含む）が10文字未満だと保存できない' do
@@ -60,7 +60,7 @@ RSpec.describe User, type: :model do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('パスワードは10文字以上で入力してください', 'パスワード半角英数字で入力してください')
+        expect(@user.errors.full_messages).to include('パスワードは10文字以上で入力してください', 'パスワードは不正な値です')
       end
       it 'パスワード（確認）が空欄だと保存できない' do
         @user.password = '123abc'


### PR DESCRIPTION
Closes #31 

# What
- ニックネーム・email・生年月日を編集できるよう実装。
- ログイン後、カレントユーザー名から画面遷移し、編集できるよう実装。

# Why
- 新規登録後、ニックネーム・email・生年月日を編集できるようにするため。